### PR TITLE
MINGW: add winsock library when linking.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,4 +187,6 @@ if(WIN32)
                 "${CMAKE_SOURCE_DIR}/Run"
             COMMENT "Copy SDL runtime DLLs to output directory")
     endif()
+
+    target_link_libraries(openfodder PRIVATE ws2_32)
 endif()


### PR DESCRIPTION
When linking the final executable, these messages were printed on the screen:
```
[5/8] Linking CXX executable openfodder.exe; Copy SDL runtime DLLs to output directory
FAILED: [code=1] openfodder.exe
CMakeFiles/openfodder.dir/Source/Utils/duk_trans_socket_windows.cpp.obj:duk_trans_socket_windows.cpp:(.text+0x44): undefined reference to `__imp_WSAStartup'
CMakeFiles/openfodder.dir/Source/Utils/duk_trans_socket_windows.cpp.obj:duk_trans_socket_windows.cpp:(.text+0x81): undefined reference to `__imp_getaddrinfo'
CMakeFiles/openfodder.dir/Source/Utils/duk_trans_socket_windows.cpp.obj:duk_trans_socket_windows.cpp:(.text+0xa0): undefined reference to `__imp_socket'
...etc
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```
So, I did a tiny patch for adding `ws2_32` and I completed the build successfully.