### PR TITLE
WIN32: add option to use system SDL3 libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project(openfodder VERSION 1.5.4 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 14)
 option(OPENFODDER_ENABLE_FFMPEG "Enable FFmpeg intro video playback" OFF)
 option(OPENFODDER_AUTO_FFMPEG "Auto-enable FFmpeg when found (non-Windows)" ON)
+option(OPENFODDER_USE_SYSTEM_SDL3 "Use system SDL3 libraries (Windows-only)" OFF)
 
 if(MSVC)
     # Enable Hot Reload (Edit and Continue) for Debug builds.
@@ -29,7 +30,7 @@ else()
 endif()
 
 if(EMSCRIPTEN)
-elseif(WIN32)
+elseif(WIN32 AND NOT OPENFODDER_USE_SYSTEM_SDL3)
     include(FetchContent)
 
     set(SDL_INSTALL OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
At the time of writing, compiling openfodder for `WIN32` needs to download and build SDL3 libraries from sources.
However, it would be useful to add an option for selecting if system libraries could be used on Windows.
So, I added `OPENFODDER_USE_SYSTEM_SDL` for this task.
By default, this option is `OFF` to reproduce the same behaviour of current sources.
If `OPENFODDER_USE_SYSTEM_SDL` is `ON`, then SDL3 libraries are used if they are found.
This simplifies the build process a lot, if you are using MinGW or MSVC together with vcpkg, without trouble in my opinion.